### PR TITLE
Add required jupytext dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,30 @@
-.DS_Store
 .ipynb_checkpoints
 napari-workshops/_build/
+
+*~
+# Byte-compiled / optimized / DLL files
+**/__pycache__
+*.py[cod]
+
+# General
+.DS_Store
+.directory
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IntelliJ project files
+.idea
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# VSCode-like project settings
+.vscode

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - jupyterlab
+  - jupytext
   - napari
   - pip
   - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jupyter-book
+jupytext
 jupyterlab
 napari[all]
 napari-animation


### PR DESCRIPTION
I am assuming that users are encouraged to run the workshop on their own machine, they will need jupytext as a dependency (unless I am missing something).
